### PR TITLE
Fix for overwriting duplicate data row of sharepoint list

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -115,7 +115,9 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                             }
                                             else
                                             {
-                                                listitem = existingItems[0];
+                                                listitem = existingItems.FirstOrDefault();
+                                                list.Context.Load(listitem);
+                                                list.Context.ExecuteQueryRetry();
                                                 processItem = true;
                                             }
                                         }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
@@ -268,6 +268,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
             var context = item.Context as ClientContext;
             var list = item.ParentList;
             context.Web.EnsureProperty(w => w.Url);
+            context.Load(list, listProperty => listProperty.BaseType, listProperty => listProperty.RootFolder);
+            context.ExecuteQueryRetry();
 
             bool isDocLib = list.EnsureProperty(l => l.BaseType) == BaseType.DocumentLibrary;
             bool isPagesLib = list.EnsureProperty(l => l.RootFolder).Name.Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);


### PR DESCRIPTION
- Involves loading of additional properties for respective list item.
- This will allow the program to overwrite duplicate rows in Sharepoint list using KeyColumn.